### PR TITLE
Poem zooming WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 node_modules/
 package.json
 package-lock.json
+
+/.luarc.json

--- a/_extensions/closeread/grid.scss
+++ b/_extensions/closeread/grid.scss
@@ -56,7 +56,11 @@
 
         // to be overruled when it is the active element
         opacity: 0;
-        transition: opacity linear 0.5s;
+        transition:
+          opacity linear 0.5s,
+          color 1s linear,
+          transform 1s ease-in-out,
+          transform-origin 1s ease-in-out;
       }
 
       // show active elements (this class is applied by scrollama
@@ -73,10 +77,7 @@
   white-space: pre;
   line-height: 1em;
   transform-origin: center center;
-  transition:
-    color 1s linear,
-    transform 1s ease-in-out,
-    transform-origin 1s ease-in-out;
+  // transform transition is applied along with all stickies
 
   // debug styling
   background-color: rgba(255, 255, 0, 0.5);

--- a/_extensions/closeread/grid.scss
+++ b/_extensions/closeread/grid.scss
@@ -66,6 +66,12 @@
 .cr-poem {
 
   font-family: Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  
+  /* need large font to stop safari text blurriness, but max-height to stop
+   other stickies from being pushed down by pre-scaled poem size */
+  max-height: 100vh; 
+  font-size: 300%;
+
   white-space: pre;
   line-height: 1em;
   

--- a/_extensions/closeread/grid.scss
+++ b/_extensions/closeread/grid.scss
@@ -19,17 +19,10 @@
       padding-block-start: 20svh;
       padding-block-end: 20svh;
       vertical-align: middle;
-      // debug styling
-      background: rgba(255, 255, 0, 0.5);
-      border: 1px solid rgba(255, 166, 0, 0.5);
 
       /* styling for actual content (*/
       > * {
         padding: 15px;
-        // debug
-        background: rgba(0, 208, 255, 0.5);
-        border: 1px solid rgba(0, 115, 255, 0.5);
-        border-radius: 5px;
       }
 
     p {
@@ -52,7 +45,6 @@
       [data-cr-id] {
         grid-area: 1 / 1;
         margin: auto;
-        // opacity: 0.5;     // lowering opacity for debug purposes
 
         // to be overruled when it is the active element
         opacity: 0;
@@ -76,13 +68,9 @@
   font-family: Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   white-space: pre;
   line-height: 1em;
-  transform-origin: center center;
+  
   // transform transition is applied along with all stickies
-
-  // debug styling
-  background-color: rgba(255, 255, 0, 0.5);
-  border: 1px solid rgba(255, 160, 0, 0.5);
-
+  transform-origin: center center;
 
   // fade the rest of the poem out when there's a highlight active
   &.cr-hl-within {
@@ -96,8 +84,31 @@
 }
 
 
-// debug
-.cr-debug .cr-crossfade {
-  background-color: #ffff0099;
-  border: 1px solid orange;
+/* debug styles */
+
+body.cr-debug {
+  
+  // give stickies borders
+  .cr-poem {
+    background-color: #ffff0099;
+    border: 1px solid orange;
+  }
+  
+  // make stickies slightly see-through
+  [data-cr-id] {
+    opacity: 0.8;
+  }
+
+  // sidebar content and scroll zone debug styles
+  .sidebar-col > * {
+    background: rgba(255, 255, 0, 0.5);
+    border: 1px solid rgba(255, 166, 0, 0.5);
+
+    > * {
+      background: rgba(0, 208, 255, 0.5);
+      border: 1px solid rgba(0, 115, 255, 0.5);
+      border-radius: 5px;
+    }    
+  }
+
 }

--- a/_extensions/closeread/grid.scss
+++ b/_extensions/closeread/grid.scss
@@ -69,17 +69,29 @@
 
 .cr-poem {
 
-  code {
-    // just a basic system serif font stack
-    font-family: Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-  }
-
+  font-family: Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  white-space: pre;
+  line-height: 1em;
   transform-origin: center center;
-  // not sure whether we want transition: transform on load
+  transition:
+    color 1s linear,
+    transform 1s ease-in-out,
+    transform-origin 1s ease-in-out;
 
   // debug styling
   background-color: rgba(255, 255, 0, 0.5);
   border: 1px solid rgba(255, 160, 0, 0.5);
+
+
+  // fade the rest of the poem out when there's a highlight active
+  &.cr-hl-within {
+    color: rgba(0, 0, 0, 0.5);
+  }
+
+  .cr-hl {
+    color: rgba(0, 0, 0, 1);
+    font-weight: bold;
+  }
 }
 
 

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -12,9 +12,10 @@ let currentIndex
 document.addEventListener("DOMContentLoaded", () => {
 
   // if debugging, add .cr-debug to the body 
-  const debugMode = document
+  const debugOption = document
     .querySelector("meta[cr-debug-mode]")?.getAttribute("cr-debug-mode")
-  if (debugMode === "true") {
+  const debugMode = debugOption === "true"
+  if (debugMode) {
     console.info("Close Read: debug mode ON")
     document.body.classList.add("cr-debug")
   }

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -144,38 +144,37 @@ function updateActivePoem(el, priorSteps) {
     .at(-1)
     ?.getAttribute("data-cr-highlight")
 
-  // no active highlight? 
-  if (activeHighlight == undefined) {
-    rescaleElement(el)
+  // no active highlight?
+  if (activeHighlight === undefined) {
+    rescaleElement(el);
   } else {
-    // highlights can currently be span ids. planning line num sets in future
-    const highlightedSpan = el.querySelector("#" + activeHighlight)
-    if (highlightedSpan != null) {
-      rescaleElement(el, highlightedSpan)
-    } else if (false) {
-      // TODO - could activeHighlight be a set of line numbers?
+    // Split the `activeHighlight` value on commas to support multiple IDs
+    const highlightIds = activeHighlight.split(',');
+    
+    // Call rescaleElement with the first found id for focusing,
+    // or without a specific focus if no ids are found 
+    if (highlightIds) {
+      rescaleElement(el, highlightIds);
     } else {
-      throw Error("Could not identify `cr-in` as either a span ID or " +
-        "a set of comma-separated line numbers. If you are specifying an ID, " +
-        "please ensure you omit the preceding #." )
+      rescaleElement(el);
     }
   }
 }
 
 /* rescaleElement:
-   given a poem element `el` (and potentially a contained span `focusEl`),
+   given a poem element `el` (and potentially a contained ids `highlightIds`),
    resets the focus status of a poem's highlight spans, then rescales (and
    potentially translates) the poem so that either the whole thing is visible
-   or the  line containing `focusEl` is visible and centerd */
-function rescaleElement(el, focusEl) {
+   or the  line containing `highlightIds` is visible and centerd */
+function rescaleElement(el, highlightIds) {
   
   // find ALL spans within the `el` and remove `.cr-hl`
   el.querySelectorAll("span[id]").forEach(d => d.classList.remove("cr-hl"))
 
-  if (focusEl == undefined) {
+  if (highlightIds == undefined) {
     scalePoemFull(el)
   } else {
-    scalePoemToSpan(el, focusEl)
+    scalePoemToSpan(el, highlightIds)
   }    
 }
 
@@ -210,10 +209,24 @@ function scalePoemFull(el, paddingX = 75, paddingY = 50) {
    given an element `el` and a span `focusEl` within it, rescales and translates
    `el` so that `focusEl` is vertically centerd and its line fills the
    containing .sticky-col-stack */
-function scalePoemToSpan(el, focusEl, paddingX = 75, paddingY = 50) {
+function scalePoemToSpan(el, highlightIds, paddingX = 75, paddingY = 50) {
 
   el.classList.add("cr-hl-within")
-  focusEl.classList.add("cr-hl")
+  //focusEl.classList.add("cr-hl")
+  
+  highlightIds.forEach(highlightId => {
+    const trimmedId = highlightId.trim(); // Ensure no whitespace issues
+    const highlightSpan = el.querySelector(`#${trimmedId}`);
+    if (highlightSpan !== null) {
+      highlightSpan.classList.add("cr-hl");
+    } else {
+    // Handle the case where the ID does not correspond to a span
+      console.warn(`Could not find span with ID '${trimmedId}'. Please ensure the ID is correct.`);
+    }
+  });
+  
+  // for now just get first span
+  const focusEl = el.querySelector(`#${highlightIds[0].trim()}`);
   
   // get dimensions of element and its container
   const container = el.closest(".sticky-col-stack")

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -182,81 +182,59 @@ function rescaleElement(el, focusEl) {
 /* scalePoemFull:
   given an element `el`, rescales it to fill its containing .sticky-col-stack */
 function scalePoemFull(el, paddingX = 75, paddingY = 50) {
-  console.log("Focusing on whole poem")
 
-  /* we need to temporarily disable `max-height: 100vh` to get the poem's real
-    height, or it won't scale properly! thankfully it remains fully visible
-    regardless of its layout height */
-  console.log("Poem height before removing maxHeight:", el.offsetHeight)
-  el.style.setProperty("max-height", "none")
-  console.log("Poem height after removing maxHeight:", el.offsetHeight)
+  console.log("Focusing on whole poem")
 
   el.classList.remove("cr-hl-within")
 
   // get dimensions of element and its container
   const container = el.closest(".sticky-col-stack")
   
-  // TODO - use scrollWidth and scrollHeight here instead?
-  const elHeight = el.offsetHeight
-  const elWidth = el.offsetWidth
+  const elHeight = el.scrollHeight
+  const elWidth = el.scrollWidth
   const containerHeight = container.offsetHeight - (paddingY * 2)
   const containerWidth = container.offsetWidth - (paddingX * 2)
 
-  // restore max-height now that we have real height for calc
-  el.style.setProperty("max-height", "100vh")
-  
   const scaleHeight = elHeight / containerHeight
   const scaleWidth = elWidth / containerWidth
   const scale = 1 / Math.max(scaleHeight, scaleWidth)
+  
+  const centreDeltaY = (elHeight - el.offsetHeight) * scale / -2
 
   // apply styles
-  el.style.setProperty("transform-origin", "center center")
   el.style.setProperty("transform",
-    `matrix(${scale}, 0, 0, ${scale}, 0, 0)`)
+    `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
 }
 
-/* scalePoemFull:
+/* scalePoemToSpan:
    given an element `el` and a span `focusEl` within it, rescales and translates
    `el` so that `focusEl` is vertically centred and its line fills the
    containing .sticky-col-stack */
 function scalePoemToSpan(el, focusEl, paddingX = 75, paddingY = 50) {
-  console.log("Focusing on span within poem")
 
-  /* we need to temporarily disable `max-height: 100vh` to get the poem's real
-    height, or it won't scale properly! thankfully it remains fully visible
-    regardless of its layout height */
-  console.log("Poem height before removing maxHeight:", el.offsetHeight)
-  el.style.setProperty("max-height", "none")
-  console.log("Poem height after removing maxHeight:", el.offsetHeight)
-    
   el.classList.add("cr-hl-within")
   focusEl.classList.add("cr-hl")
-
+  
   // get dimensions of element and its container
   const container = el.closest(".sticky-col-stack")
   
-  // TODO - use scrollWidth and scrollHeight here instead?
-  const elHeight = el.offsetHeight
-  const elWidth = el.offsetWidth
+  const elHeight = el.scrollHeight
+  const elWidth = el.scrollWidth
   const containerHeight = container.offsetHeight - (paddingY * 2)
   const containerWidth = container.offsetWidth - (paddingX * 2)
 
-  // restore max-height now that we have real height for calc
-  el.style.setProperty("max-height", "100vh")
-  
   const focusHeight = focusEl.offsetHeight
   const focusTop = focusEl.offsetTop
+  const focusCentreY = focusTop + (focusHeight / 2)
   
-  const anchorY = (focusTop + (focusHeight / 2))
-  const centreDeltaY = (elHeight / 2) - anchorY
-
   // note scaleWidth uses the whole line, not just the span width
   const scaleWidth = elWidth / containerWidth
   const scaleHeight = focusHeight / containerHeight
   const scale = 1 / Math.max(scaleHeight, scaleWidth)
+  
+  const centreDeltaY = (focusCentreY - (el.offsetHeight / 2)) * -1
 
   // apply styles
-  el.style.setProperty("transform-origin", `50% ${anchorY}px`)
   el.style.setProperty("transform",
     `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
 

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -6,7 +6,6 @@
    although users may have several scrollers in one quarto doc, i think with
    the right syntax we can get away with a single init block for everyone */
 
-console.log("Initialising scrollers...")
 const stepSelector = "[data-cr-from], [data-cr-to], [data-cr-in]"
 let currentIndex
 
@@ -27,7 +26,7 @@ document.addEventListener("DOMContentLoaded", () => {
   ojsScrollerSection?.define("crScrollerSection", null);
   ojsScrollerProgress?.define("crScrollerProgress", null);
   if (ojsModule === undefined) {
-    console.log("Warning: Quarto OJS module not found")
+    console.error("Warning: Quarto OJS module not found")
   }
 
   // let currentIndex;
@@ -41,30 +40,20 @@ document.addEventListener("DOMContentLoaded", () => {
       debug: debugMode
     })
     .onStepEnter((response) => {
-
-      console.log("Element " + response.index + "entering as we scroll " +
-      response.direction);
       
       if (response.direction == "down") {
         ojsScrollerSection?.define("crScrollerSection", response.index);
         currentIndex = response.index + 1
-        recalculateActiveSteps();
-      } else {
-         // console.log("Up and in event ignored")
+        recalculateActiveSteps()
       }
     })
     .onStepExit((response) => {
-
-      console.log("Element " + response.index + "exiting as we scroll " +
-      response.direction);
       
       if (response.direction == "up") {
         // as above, but up to the _previous_ element
         ojsScrollerSection?.define("crScrollerSection", response.index - 1);
         currentIndex = response.index
-        recalculateActiveSteps();
-      } else {
-        // console.log("Down and out event ignored")
+        recalculateActiveSteps()
       }
 
     })
@@ -140,45 +129,27 @@ function recalculateActiveSteps() {
 
   })
 
-  console.log("Active list: " + Array.from(stickiesToEnable).join(", "))
 }
 
 // make the given element active. if it's a poem, rescale it
 function updateActivePoem(el, priorSteps) {
-  console.log("Updating poem")
 
   const elId = el.getAttribute("data-cr-id")
 
-  // move work looking for focus element here
-  // TODO - now we've found the sticky to make visible, we need to determine
-  // its highlight state
-  // * traverse from the target's index (???) to
-  //   the index that triggered this update (indexTo)
-
   // active highlight is the most recent step with `cr-in` of this sticky
-  // console.log("Prior steps:", priorSteps)
-  // priorSteps.map(d => console.log("cr-id of d is ", d.getAttribute("data-cr-in")))
 
   const activeHighlight = priorSteps
-    .filter(d => {
-      console.log("Filtering prior step d:", d)
-      return d.getAttribute("data-cr-in") == elId
-    })
+    .filter(d => d.getAttribute("data-cr-in") == elId)
     .at(-1)
     ?.getAttribute("data-cr-highlight")
 
-  console.log("Active highlight:", activeHighlight)
-
   // no active highlight? 
   if (activeHighlight == undefined) {
-    console.log("No active poem highlight; rescale to full view")
     rescaleElement(el)
   } else {
-    console.log("Found a highlight; searching")
     // highlights can currently be span ids. planning line num sets in future
     const highlightedSpan = el.querySelector("#" + activeHighlight)
     if (highlightedSpan != null) {
-      console.log("Valid span found; zooming in")
       rescaleElement(el, highlightedSpan)
     } else if (false) {
       // TODO - could activeHighlight be a set of line numbers?
@@ -194,8 +165,6 @@ function updateActivePoem(el, priorSteps) {
    (if focusEl is not given) make the entire `el` visible within its container
    (if focusEl is given) make the entire `focusEl` visible within the cntnr */
 function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
-
-    console.log("Rescaling element:", el)
     
     // get dimensions of element and its container
     const container = el.closest(".sticky-col-stack")
@@ -213,20 +182,27 @@ function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
     /* if there's no focusEl, base the scale factor on el's container
     // if there IS a focusEl, scale is based poem width but not height, and
     // anchor is based on the span's location */
+
     
     if (focusEl == undefined) {
       el.classList.remove("cr-hl-within")
       
+      console.log("Focusing on whole poem")
+
       const scaleHeight = elHeight / containerHeight
       const scaleWidth = elWidth / containerWidth
 
       const scale = 1 / Math.max(scaleHeight, scaleWidth)
 
+
       // apply styles
       el.style.setProperty("transform-origin", "center center")
-      el.style.setProperty("transform", `scale(${scale})`)
+      el.style.setProperty("transform",
+        `matrix(${scale}, 0, 0, ${scale}, 0, 0)`)
   
     } else {
+
+      console.log("Focusing on span within poem")
       
       el.classList.add("cr-hl-within")
       focusEl.classList.add("cr-hl")
@@ -250,3 +226,4 @@ function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
     }    
   }
   
+

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -12,18 +12,12 @@ let currentIndex
 
 document.addEventListener("DOMContentLoaded", () => {
 
-  // first, let's read our options in from the dom
-  const debugMode =
-    document
-      .querySelector("meta[cr-debug-mode]")?.getAttribute("cr-debug-mode")
-        === "true";
-
-  // if debugging, add .cr-debug to .cr-section divs
-  // so we can add some of our own css
-  if (debugMode) {
-    document.querySelectorAll(".cr-sidebar").forEach(
-      node => node.classList.add("cr-debug")
-    )
+  // if debugging, add .cr-debug to the body 
+  const debugMode = document
+    .querySelector("meta[cr-debug-mode]")?.getAttribute("cr-debug-mode")
+  if (debugMode === "true") {
+    console.info("Close Read: debug mode ON")
+    document.body.classList.add("cr-debug")
   }
 
   // define an ojs variable if the connector module is available

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -161,11 +161,30 @@ function updateActivePoem(el, priorSteps) {
   }
 }
 
-/* Sets transform properties on an `el` to either:
-   (if focusEl is not given) make the entire `el` visible within its container
-   (if focusEl is given) make the entire `focusEl` visible within the cntnr */
-function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
-    
+/* rescaleElement:
+   given a poem element `el` (and potentially a contained span `focusEl`),
+   resets the focus status of a poem's highlight spans, then rescales (and
+   potentially translates) the poem so that either the whole thing is visible
+   or the  line containing `focusEl` is visible and centred */
+function rescaleElement(el, focusEl) {
+  
+  // find ALL spans within the `el` and remove `.cr-hl`
+  el.querySelectorAll("span[id]").forEach(d => d.classList.remove("cr-hl"))
+
+  if (focusEl == undefined) {
+    scalePoemFull(el)
+  } else {
+    scalePoemToSpan(el, focusEl)
+  }    
+}
+
+/* scalePoemFull:
+  given an element `el`, rescales it to fill its containing .sticky-col-stack */
+function scalePoemFull(el, paddingX = 50, paddingY = 50) {
+  console.log("Focusing on whole poem")
+  
+  el.classList.remove("cr-hl-within")
+
   // get dimensions of element and its container
   const container = el.closest(".sticky-col-stack")
   
@@ -174,56 +193,51 @@ function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
   const elWidth = el.offsetWidth
   const containerHeight = container.offsetHeight - (paddingY * 2)
   const containerWidth = container.offsetWidth - (paddingX * 2)
-
-  // find ALL spans within the `el` and remove `.cr-hl`
-  el.querySelectorAll("span[id]")
-    .forEach(d => d.classList.remove("cr-hl"))
-
-  /* if there's no focusEl, base the scale factor on el's container
-  // if there IS a focusEl, scale is based poem width but not height, and
-  // anchor is based on the span's location */
-
   
-  if (focusEl == undefined) {
-    el.classList.remove("cr-hl-within")
     
-    console.log("Focusing on whole poem")
+  const scaleHeight = elHeight / containerHeight
+  const scaleWidth = elWidth / containerWidth
+  const scale = 1 / Math.max(scaleHeight, scaleWidth)
 
-    const scaleHeight = elHeight / containerHeight
-    const scaleWidth = elWidth / containerWidth
-
-    const scale = 1 / Math.max(scaleHeight, scaleWidth)
-
-
-    // apply styles
-    el.style.setProperty("transform-origin", "center center")
-    el.style.setProperty("transform",
-      `matrix(${scale}, 0, 0, ${scale}, 0, 0)`)
-
-  } else {
-
-    console.log("Focusing on span within poem")
-    
-    el.classList.add("cr-hl-within")
-    focusEl.classList.add("cr-hl")
-    
-    const focusHeight = focusEl.offsetHeight
-    const focusTop = focusEl.offsetTop
-    
-    const anchorY = (focusTop + (focusHeight / 2))
-    const centreDeltaY = (elHeight / 2) - anchorY
-
-    // note scaleWidth uses the whole line, not just the span width
-    const scaleWidth = elWidth / containerWidth
-    const scaleHeight = focusHeight / containerHeight
-    const scale = 1 / Math.max(scaleHeight, scaleWidth)
-
-    // apply styles
-    el.style.setProperty("transform-origin", `50% ${anchorY}px`)
-    el.style.setProperty("transform",
-      `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
-
-  }    
+  // apply styles
+  el.style.setProperty("transform-origin", "center center")
+  el.style.setProperty("transform",
+    `matrix(${scale}, 0, 0, ${scale}, 0, 0)`)
 }
 
+/* scalePoemFull:
+   given an element `el` and a span `focusEl` within it, rescales and translates
+   `el` so that `focusEl` is vertically centred and its line fills the
+   containing .sticky-col-stack */
+function scalePoemToSpan(el, focusEl, paddingX = 50, paddingY = 50) {
+  console.log("Focusing on span within poem")
+    
+  el.classList.add("cr-hl-within")
+  focusEl.classList.add("cr-hl")
 
+  // get dimensions of element and its container
+  const container = el.closest(".sticky-col-stack")
+  
+  // TODO - use scrollWidth and scrollHeight here instead?
+  const elHeight = el.offsetHeight
+  const elWidth = el.offsetWidth
+  const containerHeight = container.offsetHeight - (paddingY * 2)
+  const containerWidth = container.offsetWidth - (paddingX * 2)
+  
+  const focusHeight = focusEl.offsetHeight
+  const focusTop = focusEl.offsetTop
+  
+  const anchorY = (focusTop + (focusHeight / 2))
+  const centreDeltaY = (elHeight / 2) - anchorY
+
+  // note scaleWidth uses the whole line, not just the span width
+  const scaleWidth = elWidth / containerWidth
+  const scaleHeight = focusHeight / containerHeight
+  const scale = 1 / Math.max(scaleHeight, scaleWidth)
+
+  // apply styles
+  el.style.setProperty("transform-origin", `50% ${anchorY}px`)
+  el.style.setProperty("transform",
+    `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
+
+}

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -139,9 +139,9 @@ function recalculateActiveSteps() {
 
     // do the visibility update
     targets[0].classList.add("cr-active")
-      if (targets[0].classList.contains("cr-poem")) {
-        updateActivePoem(targets[0], priorSteps)
-      }
+    if (targets[0].classList.contains("cr-poem")) {
+      updateActivePoem(targets[0], priorSteps)
+    }
 
 
   })
@@ -199,7 +199,7 @@ function updateActivePoem(el, priorSteps) {
 /* Sets transform properties on an `el` to either:
    (if focusEl is not given) make the entire `el` visible within its container
    (if focusEl is given) make the entire `focusEl` visible within the cntnr */
-   function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
+function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
 
     console.log("Rescaling element:", el)
     
@@ -216,47 +216,42 @@ function updateActivePoem(el, priorSteps) {
     el.querySelectorAll("span[id]")
       .forEach(d => d.classList.remove("cr-hl"))
   
+    /* if there's no focusEl, base the scale factor on el's container
+    // if there IS a focusEl, scale is based poem width but not height, and
+    // anchor is based on the span's location */
+    
     if (focusEl == undefined) {
       el.classList.remove("cr-hl-within")
-
-      // if there's no focusEl, base the scale factor on el's container
+      
       const scaleHeight = elHeight / containerHeight
       const scaleWidth = elWidth / containerWidth
-      let origin, translateY
 
-      // TODO - make the transform anchor the centre of el
-      // anchor = "tans"
       const scale = 1 / Math.max(scaleHeight, scaleWidth)
-      if (elHeight > containerHeight) {
-        origin = "top center"
-        translateY = `translateY(${paddingY}px)`
-      } else {
-        origin = "center center"
-        translateY = `translateY(0)`
-      }
-  
-      el.setAttribute("style",
-        `transform-origin: ${origin}; transform: ${translateY} scale(${scale});;`)
+
+      // apply styles
+      el.style.setProperty("transform-origin", "center center")
+      el.style.setProperty("transform", `scale(${scale})`)
   
     } else {
-      // if there IS a focusEl, scale is based on span
+      
       el.classList.add("cr-hl-within")
       focusEl.classList.add("cr-hl")
       
       const focusHeight = focusEl.offsetHeight
-      const focusWidth = focusEl.offsetWidth
-      const scaleWidth = focusWidth / containerWidth
+      const focusTop = focusEl.offsetTop
+      
+      const anchorY = (focusTop + (focusHeight / 2))
+      const centreDeltaY = (elHeight / 2) - anchorY
+
+      // note scaleWidth uses the whole line, not just the span width
+      const scaleWidth = elWidth / containerWidth
       const scaleHeight = focusHeight / containerHeight
       const scale = 1 / Math.max(scaleHeight, scaleWidth)
-      
-      // also need anchor point! i _think_ the transform-origin should be
-      // unscaled, but the translation to bring it to center should be scaled?
-      // TODO - this math ain't workin'
-      const anchorX = ((focusWidth / 2) - (elWidth / 2))
-      const anchorY = ((focusHeight / 2) - (elHeight / 2))
 
-      el.setAttribute("style",
-        `transform-origin: ${anchorX}px ${anchorY}px; transform: translate(${anchorX * scale}px, ${anchorY * scale}px) scale(${scale});`)
+      // apply styles
+      el.style.setProperty("transform-origin", `50% ${anchorY}px`)
+      el.style.setProperty("transform",
+        `translateY(${centreDeltaY}px) scale(${scale})`)
   
     }    
   }

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -166,7 +166,7 @@ function updateActivePoem(el, priorSteps) {
    given a poem element `el` (and potentially a contained span `focusEl`),
    resets the focus status of a poem's highlight spans, then rescales (and
    potentially translates) the poem so that either the whole thing is visible
-   or the  line containing `focusEl` is visible and centred */
+   or the  line containing `focusEl` is visible and centerd */
 function rescaleElement(el, focusEl) {
   
   // find ALL spans within the `el` and remove `.cr-hl`
@@ -199,16 +199,16 @@ function scalePoemFull(el, paddingX = 75, paddingY = 50) {
   const scaleWidth = elWidth / containerWidth
   const scale = 1 / Math.max(scaleHeight, scaleWidth)
   
-  const centreDeltaY = (elHeight - el.offsetHeight) * scale / -2
+  const centerDeltaY = (elHeight - el.offsetHeight) * scale / -2
 
   // apply styles
   el.style.setProperty("transform",
-    `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
+    `matrix(${scale}, 0, 0, ${scale}, 0, ${centerDeltaY})`)
 }
 
 /* scalePoemToSpan:
    given an element `el` and a span `focusEl` within it, rescales and translates
-   `el` so that `focusEl` is vertically centred and its line fills the
+   `el` so that `focusEl` is vertically centerd and its line fills the
    containing .sticky-col-stack */
 function scalePoemToSpan(el, focusEl, paddingX = 75, paddingY = 50) {
 
@@ -232,10 +232,10 @@ function scalePoemToSpan(el, focusEl, paddingX = 75, paddingY = 50) {
   const scaleHeight = focusHeight / containerHeight
   const scale = 1 / Math.max(scaleHeight, scaleWidth)
   
-  const centreDeltaY = (focusCentreY - (el.offsetHeight / 2)) * -1
+  const centerDeltaY = (focusCentreY - (el.offsetHeight / 2)) * -1
 
   // apply styles
   el.style.setProperty("transform",
-    `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
+    `matrix(${scale}, 0, 0, ${scale}, 0, ${centerDeltaY})`)
 
 }

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -181,9 +181,16 @@ function rescaleElement(el, focusEl) {
 
 /* scalePoemFull:
   given an element `el`, rescales it to fill its containing .sticky-col-stack */
-function scalePoemFull(el, paddingX = 50, paddingY = 50) {
+function scalePoemFull(el, paddingX = 75, paddingY = 50) {
   console.log("Focusing on whole poem")
-  
+
+  /* we need to temporarily disable `max-height: 100vh` to get the poem's real
+    height, or it won't scale properly! thankfully it remains fully visible
+    regardless of its layout height */
+  console.log("Poem height before removing maxHeight:", el.offsetHeight)
+  el.style.setProperty("max-height", "none")
+  console.log("Poem height after removing maxHeight:", el.offsetHeight)
+
   el.classList.remove("cr-hl-within")
 
   // get dimensions of element and its container
@@ -194,8 +201,10 @@ function scalePoemFull(el, paddingX = 50, paddingY = 50) {
   const elWidth = el.offsetWidth
   const containerHeight = container.offsetHeight - (paddingY * 2)
   const containerWidth = container.offsetWidth - (paddingX * 2)
+
+  // restore max-height now that we have real height for calc
+  el.style.setProperty("max-height", "100vh")
   
-    
   const scaleHeight = elHeight / containerHeight
   const scaleWidth = elWidth / containerWidth
   const scale = 1 / Math.max(scaleHeight, scaleWidth)
@@ -210,8 +219,15 @@ function scalePoemFull(el, paddingX = 50, paddingY = 50) {
    given an element `el` and a span `focusEl` within it, rescales and translates
    `el` so that `focusEl` is vertically centred and its line fills the
    containing .sticky-col-stack */
-function scalePoemToSpan(el, focusEl, paddingX = 50, paddingY = 50) {
+function scalePoemToSpan(el, focusEl, paddingX = 75, paddingY = 50) {
   console.log("Focusing on span within poem")
+
+  /* we need to temporarily disable `max-height: 100vh` to get the poem's real
+    height, or it won't scale properly! thankfully it remains fully visible
+    regardless of its layout height */
+  console.log("Poem height before removing maxHeight:", el.offsetHeight)
+  el.style.setProperty("max-height", "none")
+  console.log("Poem height after removing maxHeight:", el.offsetHeight)
     
   el.classList.add("cr-hl-within")
   focusEl.classList.add("cr-hl")
@@ -224,6 +240,9 @@ function scalePoemToSpan(el, focusEl, paddingX = 50, paddingY = 50) {
   const elWidth = el.offsetWidth
   const containerHeight = container.offsetHeight - (paddingY * 2)
   const containerWidth = container.offsetWidth - (paddingX * 2)
+
+  // restore max-height now that we have real height for calc
+  el.style.setProperty("max-height", "100vh")
   
   const focusHeight = focusEl.offsetHeight
   const focusTop = focusEl.offsetTop

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -251,7 +251,7 @@ function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
       // apply styles
       el.style.setProperty("transform-origin", `50% ${anchorY}px`)
       el.style.setProperty("transform",
-        `translateY(${centreDeltaY}px) scale(${scale})`)
+        `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
   
     }    
   }

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -166,64 +166,64 @@ function updateActivePoem(el, priorSteps) {
    (if focusEl is given) make the entire `focusEl` visible within the cntnr */
 function rescaleElement(el, focusEl, paddingX = 50, paddingY = 50) {
     
-    // get dimensions of element and its container
-    const container = el.closest(".sticky-col-stack")
+  // get dimensions of element and its container
+  const container = el.closest(".sticky-col-stack")
+  
+  // TODO - use scrollWidth and scrollHeight here instead?
+  const elHeight = el.offsetHeight
+  const elWidth = el.offsetWidth
+  const containerHeight = container.offsetHeight - (paddingY * 2)
+  const containerWidth = container.offsetWidth - (paddingX * 2)
+
+  // find ALL spans within the `el` and remove `.cr-hl`
+  el.querySelectorAll("span[id]")
+    .forEach(d => d.classList.remove("cr-hl"))
+
+  /* if there's no focusEl, base the scale factor on el's container
+  // if there IS a focusEl, scale is based poem width but not height, and
+  // anchor is based on the span's location */
+
+  
+  if (focusEl == undefined) {
+    el.classList.remove("cr-hl-within")
     
-    // TODO - use scrollWidth and scrollHeight here instead?
-    const elHeight = el.offsetHeight
-    const elWidth = el.offsetWidth
-    const containerHeight = container.offsetHeight - (paddingY * 2)
-    const containerWidth = container.offsetWidth - (paddingX * 2)
+    console.log("Focusing on whole poem")
 
-    // find ALL spans within the `el` and remove `.cr-hl`
-    el.querySelectorAll("span[id]")
-      .forEach(d => d.classList.remove("cr-hl"))
-  
-    /* if there's no focusEl, base the scale factor on el's container
-    // if there IS a focusEl, scale is based poem width but not height, and
-    // anchor is based on the span's location */
+    const scaleHeight = elHeight / containerHeight
+    const scaleWidth = elWidth / containerWidth
 
+    const scale = 1 / Math.max(scaleHeight, scaleWidth)
+
+
+    // apply styles
+    el.style.setProperty("transform-origin", "center center")
+    el.style.setProperty("transform",
+      `matrix(${scale}, 0, 0, ${scale}, 0, 0)`)
+
+  } else {
+
+    console.log("Focusing on span within poem")
     
-    if (focusEl == undefined) {
-      el.classList.remove("cr-hl-within")
-      
-      console.log("Focusing on whole poem")
+    el.classList.add("cr-hl-within")
+    focusEl.classList.add("cr-hl")
+    
+    const focusHeight = focusEl.offsetHeight
+    const focusTop = focusEl.offsetTop
+    
+    const anchorY = (focusTop + (focusHeight / 2))
+    const centreDeltaY = (elHeight / 2) - anchorY
 
-      const scaleHeight = elHeight / containerHeight
-      const scaleWidth = elWidth / containerWidth
+    // note scaleWidth uses the whole line, not just the span width
+    const scaleWidth = elWidth / containerWidth
+    const scaleHeight = focusHeight / containerHeight
+    const scale = 1 / Math.max(scaleHeight, scaleWidth)
 
-      const scale = 1 / Math.max(scaleHeight, scaleWidth)
+    // apply styles
+    el.style.setProperty("transform-origin", `50% ${anchorY}px`)
+    el.style.setProperty("transform",
+      `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
 
+  }    
+}
 
-      // apply styles
-      el.style.setProperty("transform-origin", "center center")
-      el.style.setProperty("transform",
-        `matrix(${scale}, 0, 0, ${scale}, 0, 0)`)
-  
-    } else {
-
-      console.log("Focusing on span within poem")
-      
-      el.classList.add("cr-hl-within")
-      focusEl.classList.add("cr-hl")
-      
-      const focusHeight = focusEl.offsetHeight
-      const focusTop = focusEl.offsetTop
-      
-      const anchorY = (focusTop + (focusHeight / 2))
-      const centreDeltaY = (elHeight / 2) - anchorY
-
-      // note scaleWidth uses the whole line, not just the span width
-      const scaleWidth = elWidth / containerWidth
-      const scaleHeight = focusHeight / containerHeight
-      const scale = 1 / Math.max(scaleHeight, scaleWidth)
-
-      // apply styles
-      el.style.setProperty("transform-origin", `50% ${anchorY}px`)
-      el.style.setProperty("transform",
-        `matrix(${scale}, 0, 0, ${scale}, 0, ${centreDeltaY})`)
-  
-    }    
-  }
-  
 

--- a/demo-block-types.qmd
+++ b/demo-block-types.qmd
@@ -108,31 +108,7 @@ This is a poem. It's called ["Bellringer", by Rita Dove](https://www.newyorker.c
 | of my birth]{#cr-birth} and Mr. Jefferson’s death
 | in one breath, voices [dusted with wonderment]{#cr-wonder},
 | faint sunlight quivering on a hidden breeze.
-| 
-| Ad qui reprehenderit aliquip fugiat nostrud
-| laborum amet et nostrud eu excepteur eu duis
-| dolore excepteur. Laborum amet culpa pariatur
-| veniam eu. Pariatur laboris sit culpa laboris
-| qui ipsum in enim sit eiusmod ullamco irure.
-| Aliqua qui et nulla eiusmod occaecat anim.
-| Esse laboris occaecat sit id consectetur in
-| magna reprehenderit ut quis sit. Aliquip
-| cupidatat cupidatat nostrud proident in.
-| 
-| Fugiat sint aliquip quis aute reprehenderit. Lorem
-| ullamco laboris minim eiusmod elit laborum sit amet
-| proident eiusmod sunt aliquip ex. Ea velit nisi eu
-| sunt duis irure ipsum officia non fugiat laborum.
-| Adipisicing non tempor consequat culpa sunt aliqua
-| fugiat veniam.
-| 
-| Minim tempor enim labore. Quis voluptate ad sint anim
-| velit culpa proident quis adipisicing irure eiusmod
-| minim excepteur. Officia occaecat cillum ex nulla
-| ipsum incididunt. Anim proident Lorem veniam
-| consectetur quis proident eu et sunt. Lorem culpa et
-| deserunt et elit ut elit cupidatat laboris elit veniam
-| enim est amet nisi. Aliquip velit commodo exercitation.
+
 
 :::{cr-in="mypoem" cr-highlight="cr-born"}
 The author refers to their birth twice: one here...

--- a/demo-block-types.qmd
+++ b/demo-block-types.qmd
@@ -87,61 +87,78 @@ $$
 :::
 
 :::{.cr-crossfade cr-from="displaymath" cr-to="mypoem"}
-This is a poem. It's called ["Bellringer", by Rita Dove](https://www.newyorker.com/culture/2019-in-review/our-year-in-poems). I've thrown some lorem ipsum on after to make it too long for most screens.
+This is a poem. It's called ["Bellringer", by Rita Dove](https://www.newyorker.com/culture/2019-in-review/our-year-in-poems).
 :::
 
-```{.cr-poem cr-id="mypoem"}
-I was given a name, it came out of a book—
-I don’t know which. I’ve been told the Great Man
-could recite every title in order on its shelf.
-Well, I was born, and that’s a good thing,
-although I arrived on the day of his passing,
+| {#longpoem .cr-poem cr-id="mypoem"}
+| I was given a name, it came out of a book—
+| I don’t know which. I’ve been told the Great Man
+| could recite every title in order on its shelf.
+| Well, [I was born]{#cr-born}, and that’s a good thing,
+| although I arrived on the day of his passing,
+| 
+| a day on which our country fell into mourning.
+| This I heard over and over, from professors
+| to farmers, even duel-scarred students;
+| sometimes, in grand company, remarked upon
+| in third person—a pretty way of saying
+| 
+| more than two men in a room means the third
+| can be ignored, as [I was when they spoke
+| of my birth]{#cr-birth} and Mr. Jefferson’s death
+| in one breath, voices [dusted with wonderment]{#cr-wonder},
+| faint sunlight quivering on a hidden breeze.
+| 
+| Ad qui reprehenderit aliquip fugiat nostrud
+| laborum amet et nostrud eu excepteur eu duis
+| dolore excepteur. Laborum amet culpa pariatur
+| veniam eu. Pariatur laboris sit culpa laboris
+| qui ipsum in enim sit eiusmod ullamco irure.
+| Aliqua qui et nulla eiusmod occaecat anim.
+| Esse laboris occaecat sit id consectetur in
+| magna reprehenderit ut quis sit. Aliquip
+| cupidatat cupidatat nostrud proident in.
+| 
+| Fugiat sint aliquip quis aute reprehenderit. Lorem
+| ullamco laboris minim eiusmod elit laborum sit amet
+| proident eiusmod sunt aliquip ex. Ea velit nisi eu
+| sunt duis irure ipsum officia non fugiat laborum.
+| Adipisicing non tempor consequat culpa sunt aliqua
+| fugiat veniam.
+| 
+| Minim tempor enim labore. Quis voluptate ad sint anim
+| velit culpa proident quis adipisicing irure eiusmod
+| minim excepteur. Officia occaecat cillum ex nulla
+| ipsum incididunt. Anim proident Lorem veniam
+| consectetur quis proident eu et sunt. Lorem culpa et
+| deserunt et elit ut elit cupidatat laboris elit veniam
+| enim est amet nisi. Aliquip velit commodo exercitation.
 
-a day on which our country fell into mourning.
-This I heard over and over, from professors
-to farmers, even duel-scarred students;
-sometimes, in grand company, remarked upon
-in third person—a pretty way of saying
+:::{cr-in="mypoem" cr-highlight="cr-born"}
+The author refers to their birth twice: one here...
+:::
 
-more than two men in a room means the third
-can be ignored, as I was when they spoke
-of my birth and Mr. Jefferson’s death
-in one breath, voices dusted with wonderment,
-faint sunlight quivering on a hidden breeze.
+:::{cr-in="mypoem" cr-highlight="cr-birth"}
+... and again, further down.
 
-Eu ipsum et cillum ex et ut duis officia et.
-Et incididunt mollit dolore mollit nisi veniam
-  id qui sit est proident eu enim duis.
-Anim aliquip consectetur ea veniam nulla do aute
-  officia proident eiusmod consequat proident.
-Et non ut tempor consectetur labore.
+Interestingly, Pandoc doesn't let you carry a span across two lines in a line block!
+:::
 
-Ipsum in adipisicing veniam et est adipisicing
-  eiusmod aute elit.
-Sit fugiat laborum enim.
-Qui elit velit voluptate commodo laboris eiusmod
-  fugiat quis aliquip elit in officia fugiat laborum.
-Commodo dolor fugiat eiusmod consectetur.
-Et eu ut proident voluptate tempor.
-
-Ea eu culpa id irure occaecat fugiat ullamco.
-Fugiat esse fugiat laboris nulla eiusmod
-  reprehenderit incididunt.
-Nisi consequat cillum eu ipsum anim ullamco ut.
-Fugiat veniam veniam duis aliqua ex occaecat.
-Laboris nostrud excepteur aliquip proident aliquip.
-Ex non dolor consequat laboris fugiat occaecat sint qui.
-Non commodo cillum minim aliqua non nisi anim id
-  officia est dolor.
-```
+:::{cr-in="mypoem" cr-highlight="cr-wonder"}
+But check out this phrase, right at the bottom.
+:::
 
 :::{.cr-crossfade cr-from="mypoem" cr-to="mylimerick"}
-And here is a short limerick.
+Let's look at a small limmerick.
 :::
 
-| {#something .myclass cr-id="mylimerick" myattr="true"}
+| {#something .cr-poem cr-id="mylimerick" myattr="true"}
 | The limerick packs [laughs anatomical]{#cr-laughs}
 |   In space that is quite economical.
+
+:::{cr-in="mylimerick" cr-highlight="cr-laughs"}
+The phrase 'laughs anatomical' is quite important here!
+:::
 
 :::{.cr-crossfade cr-from="mylimerick" cr-to="mermaid"}
 This is a mermaid diagram

--- a/demo-block-types.qmd
+++ b/demo-block-types.qmd
@@ -104,8 +104,8 @@ This is a poem. It's called ["Bellringer", by Rita Dove](https://www.newyorker.c
 | in third person—a pretty way of saying
 | 
 | more than two men in a room means the third
-| can be ignored, as [I was when they spoke
-| of my birth]{#cr-birth} and Mr. Jefferson’s death
+| can be ignored, as [I was when they spoke]{#cr-birth1}
+| [of my birth]{#cr-birth2} and Mr. Jefferson’s death
 | in one breath, voices [dusted with wonderment]{#cr-wonder},
 | faint sunlight quivering on a hidden breeze.
 
@@ -114,7 +114,7 @@ This is a poem. It's called ["Bellringer", by Rita Dove](https://www.newyorker.c
 The author refers to their birth twice: one here...
 :::
 
-:::{cr-in="mypoem" cr-highlight="cr-birth"}
+:::{cr-in="mypoem" cr-highlight="cr-birth1,cr-birth2"}
 ... and again, further down.
 
 Interestingly, Pandoc doesn't let you carry a span across two lines in a line block!


### PR DESCRIPTION
Here's my first swing at the poem zooming effect! I've done some refactoring to keep it as performant as I can (although I suspect this chain-of-transactions pattern I'm naively writing could be done more formally and performantly).

That said, the maths on the zooming isn't working, so you'll notice the poem is zooming off screen right now. Would love a second pair of eyes on this when you have some time, @andrewpbray; you might have a better intuition than me! It's at about L241 of scroller-init.js. 

There's another issue that's a bit of a pin:

Unlike Chrome, Safari appears to masterise text before you apply a transform to it (in some circumstances—I've occasionally managed to get sharp text, mostly when I'm not using a translation, but it's tricky to reproduce!), so small poems that get scaled (scale >> 1) up appear pixelated.

When I look at how Reveal's auto sizing works, they do the opposite: start big and (mostly) scale down. They specify a "natural" width and height and the scaling based off that. So if your natural height and width are high (eg. 1400px), most of the scaling is downward.

So we could specify a large font size for poems and then scale them down.

The trouble is, when a poem is too big for the screen and is scaled down, it still reserves layout space based on its original size. That causes other stickies to miss when it comes to their margins and be pushed down (unless we just decide to apply the transform to _all the stickies?_).
