### PR TITLE
initialize crScrollerSection and crScrollerProgress at 0 instead of null

### DIFF
--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -24,8 +24,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const ojsModule = window._ojs?.ojsConnector?.mainModule
   const ojsScrollerSection = ojsModule?.variable();
   const ojsScrollerProgress = ojsModule?.variable();
-  ojsScrollerSection?.define("crScrollerSection", null);
-  ojsScrollerProgress?.define("crScrollerProgress", null);
+  ojsScrollerSection?.define("crScrollerSection", 0);
+  ojsScrollerProgress?.define("crScrollerProgress", 0);
   if (ojsModule === undefined) {
     console.error("Warning: Quarto OJS module not found")
   }

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -60,12 +60,7 @@ document.addEventListener("DOMContentLoaded", () => {
     })
     .onStepProgress((response) => {
       // { element, index, progress }
-      ojsScrollerProgress?.define("crScrollerProgress",
-        response.progress.toLocaleString("en-US", {
-          style: "percent"
-        }) + " " +
-        (response.direction == "down" ? "↓" : "↑"));
-
+      ojsScrollerProgress?.define("crScrollerProgress", response.progress);
     });
 
     // also recalc transitions and highlights on window resize


### PR DESCRIPTION
Interestingly, this doesn't fully solve the problem. If you try rendering `demo-block-types.qmd`, you'll see that the first transition, to pink-desktop, doesn't trigger adding to the index, so it stays at zero. When you scroll back up to the top, though, it does trigger subtracting from the index, so it goes to -1.

🤔 