### PR TITLE
Fix OJS variables

### DIFF
--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -24,8 +24,10 @@ document.addEventListener("DOMContentLoaded", () => {
   const ojsModule = window._ojs?.ojsConnector?.mainModule
   const ojsScrollerSection = ojsModule?.variable();
   const ojsScrollerProgress = ojsModule?.variable();
+  const ojsScrollerDirection = ojsModule?.variable();
   ojsScrollerSection?.define("crScrollerSection", focusedSticky);
   ojsScrollerProgress?.define("crScrollerProgress", 0);
+  ojsScrollerDirection?.define("crScrollerDirection", null);
   if (ojsModule === undefined) {
     console.error("Warning: Quarto OJS module not found")
   }
@@ -62,6 +64,8 @@ document.addEventListener("DOMContentLoaded", () => {
       // { element, index, progress }
       ojsScrollerProgress?.define("crScrollerProgress",
         response.progress);
+      ojsScrollerDirection?.define("crScrollerDirection",
+        response.direction);
     });
 
     // also recalc transitions and highlights on window resize

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -22,10 +22,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // define an ojs variable if the connector module is available
   const ojsModule = window._ojs?.ojsConnector?.mainModule
-  const ojsScrollerSection = ojsModule?.variable();
+  const ojsScrollerName = ojsModule?.variable();
   const ojsScrollerProgress = ojsModule?.variable();
   const ojsScrollerDirection = ojsModule?.variable();
-  ojsScrollerSection?.define("crScrollerSection", focusedSticky);
+  ojsScrollerName?.define("crScrollerName", focusedSticky);
   ojsScrollerProgress?.define("crScrollerProgress", 0);
   ojsScrollerDirection?.define("crScrollerDirection", null);
   if (ojsModule === undefined) {
@@ -45,18 +45,31 @@ document.addEventListener("DOMContentLoaded", () => {
     .onStepEnter((response) => {
       
       if (response.direction == "down") {
-        ojsScrollerSection?.define("crScrollerSection", response.index);
-        currentIndex = response.index + 1
-        recalculateActiveSteps()
+        focusedStickyName = getActiveSticky(response);
+        ojsScrollerName?.define("crScrollerName", focusedStickyName);
+        
+        // applyFocusOn
+        allStickies.forEach(node => {node.classList.remove("cr-active")});
+        const focusedSticky = document.querySelectorAll("[data-cr-id=" + focusedStickyName + "]")[0]
+        focusedSticky.classList.add("cr-active");
+        
+        // applyHighlightSpans
+        highlightSpans(focusedSticky, response.element);
       }
     })
     .onStepExit((response) => {
       
       if (response.direction == "up") {
-        // as above, but up to the _previous_ element
-        ojsScrollerSection?.define("crScrollerSection", response.index - 1);
-        currentIndex = response.index
-        recalculateActiveSteps()
+        focusedStickyName = getActiveSticky(response);
+        ojsScrollerName?.define("crScrollerName", focusedStickyName);
+        
+        // applyFocusOn
+        allStickies.forEach(node => {node.classList.remove("cr-active")});
+        const focusedSticky = document.querySelectorAll("[data-cr-id=" + focusedStickyName + "]")[0]
+        focusedSticky.classList.add("cr-active");
+        
+        // applyHighlightSpans
+        highlightSpans(focusedSticky, response.element);
       }
 
     })

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -24,8 +24,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const ojsModule = window._ojs?.ojsConnector?.mainModule
   const ojsScrollerSection = ojsModule?.variable();
   const ojsScrollerProgress = ojsModule?.variable();
-  ojsScrollerSection?.define("crScrollerSection", null);
-  ojsScrollerProgress?.define("crScrollerProgress", null);
+  ojsScrollerSection?.define("crScrollerSection", focusedSticky);
+  ojsScrollerProgress?.define("crScrollerProgress", 0);
   if (ojsModule === undefined) {
     console.error("Warning: Quarto OJS module not found")
   }
@@ -61,11 +61,7 @@ document.addEventListener("DOMContentLoaded", () => {
     .onStepProgress((response) => {
       // { element, index, progress }
       ojsScrollerProgress?.define("crScrollerProgress",
-        response.progress.toLocaleString("en-US", {
-          style: "percent"
-        }) + " " +
-        (response.direction == "down" ? "↓" : "↑"));
-
+        response.progress);
     });
 
     // also recalc transitions and highlights on window resize


### PR DESCRIPTION
Changes the names of the Observable JavaScript variables available to users, makes the progress variable numeric (instead of a string), and breaks the direction out as a separate variable.

This cherry picks the commits from #33 so that we can unblock some OJS demos.