### PR TITLE
Apply bootswatch theme to narrative col and sticky col

### DIFF
--- a/_extensions/closeread/closeread.lua
+++ b/_extensions/closeread/closeread.lua
@@ -2,7 +2,6 @@
 quarto.log.output("===== Closeread Log =====")
 
 -- set defaults
-local debug_mode = false
 local step_selectors = {["focus-on"] = true}
 
 -- Append attributes to any cr line blocks
@@ -86,14 +85,30 @@ end
 
 
 -- Read in YAML options
+
+-- set defaults
+local debug_mode = false
+local narrative_col_bg = "light"
+
 function read_meta(m)
 
+  ----------------
+  -- debug mode --
+  ----------------
   if m["debug-mode"] ~= nil then
     debug_mode = m["debug-mode"]
   end
   
   -- make accessible to scroller-init.js via <meta> tag
   quarto.doc.include_text("in-header", "<meta cr-debug-mode='" .. tostring(debug_mode) .. "'>")
+  
+  
+  -----------------
+  -- tweak theme --
+  -----------------
+  if m["narrative-col-bg"] ~= nil then
+    narrative_col_bg = m["narrative-col-bg"][1].text
+  end
   
 end
 
@@ -133,7 +148,7 @@ function make_sidebar_layout(div)
     }
 
     narrative_col = pandoc.Div(narrative_blocks,
-      pandoc.Attr("", {"sidebar-col"}, {}))
+      pandoc.Attr("", {"sidebar-col", "bg-" .. narrative_col_bg}, {}))
     sticky_col_stack = pandoc.Div(sticky_blocks,
       pandoc.Attr("", {"sticky-col-stack"}))
     sticky_col = pandoc.Div(sticky_col_stack,
@@ -251,6 +266,6 @@ quarto.doc.add_html_dependency({
 
 return {
   {LineBlock = add_attributes},
-  {Meta = read_meta,
-  Div = make_sidebar_layout}
+  {Meta = read_meta},
+  {Div = make_sidebar_layout}
 }

--- a/docs/gallery/demos/sticky-block-types/index.qmd
+++ b/docs/gallery/demos/sticky-block-types/index.qmd
@@ -2,6 +2,7 @@
 format:
   closeread-html:
     debug-mode: false
+    narrative-col-bg: primary
 ---
 
 ::::{.cr-layout}


### PR DESCRIPTION
One thorny thing that needs to be sorted out: right now the addition of `bg-light` by default screws with the nytimes demo. What's the best way to sort that out so that the nytimes styling takes precedent?

Perhaps by requiring that any secondary theme specify all of the style attributes specified by the bootswatch theme otherwise it's fine to use bootswatch?