### PR TITLE
Option to remove title block and header space

### DIFF
--- a/_extensions/closeread/closeread.lua
+++ b/_extensions/closeread/closeread.lua
@@ -1,9 +1,11 @@
 
 quarto.log.output("===== Closeread Log =====")
+quarto.log.output("HELLO")
 
 -- set defaults
 local debug_mode = false
 local step_selectors = {["focus-on"] = true}
+local remove_header_space = false
 
 -- Append attributes to any cr line blocks
 function add_attributes(lineblock)
@@ -83,18 +85,32 @@ function extractClasses(el)
   return classes
 end
 
-
-
 -- Read in YAML options
 function read_meta(m)
 
   if m["debug-mode"] ~= nil then
     debug_mode = m["debug-mode"]
   end
+
+  if m["remove-header-space"] ~= nil then
+    remove_header_space = m["remove-header-space"]
+  end
   
   -- make accessible to scroller-init.js via <meta> tag
   quarto.doc.include_text("in-header", "<meta cr-debug-mode='" .. tostring(debug_mode) .. "'>")
+
+  -- same for remove_header_space
+  -- TODO - would love to find a way to do this without js by attaching the
+  -- class to <body> directly
+  quarto.doc.include_text("in-header", "<meta cr-remove-header-space='" .. tostring(remove_header_space) .. "'>")
   
+end
+
+function add_classes_to_body(p)
+  quarto.log.output(">>> Printing pandoc p.blocks")
+  quarto.log.output(p.blocks)
+  -- TODO - i was hoping <body> would be in here, but it starts with
+  -- the .cr-layout... not sure how to attach a class to <body>
 end
 
 -- Construct sticky sidebar AST
@@ -250,7 +266,12 @@ quarto.doc.add_html_dependency({
 -- TODO - add a js scrollama setup step (can i do this with a js script + yaml?)
 
 return {
-  {LineBlock = add_attributes},
-  {Meta = read_meta,
-  Div = make_sidebar_layout}
+  {
+    LineBlock = add_attributes
+  },
+  {
+    Meta = read_meta,
+    Div = make_sidebar_layout,
+    Pandoc = add_classes_to_body
+  }
 }

--- a/_extensions/closeread/closeread.lua
+++ b/_extensions/closeread/closeread.lua
@@ -1,6 +1,5 @@
 
 quarto.log.output("===== Closeread Log =====")
-quarto.log.output("HELLO")
 
 -- set defaults
 local debug_mode = false

--- a/_extensions/closeread/closeread.lua
+++ b/_extensions/closeread/closeread.lua
@@ -100,17 +100,8 @@ function read_meta(m)
   quarto.doc.include_text("in-header", "<meta cr-debug-mode='" .. tostring(debug_mode) .. "'>")
 
   -- same for remove_header_space
-  -- TODO - would love to find a way to do this without js by attaching the
-  -- class to <body> directly
   quarto.doc.include_text("in-header", "<meta cr-remove-header-space='" .. tostring(remove_header_space) .. "'>")
   
-end
-
-function add_classes_to_body(p)
-  quarto.log.output(">>> Printing pandoc p.blocks")
-  quarto.log.output(p.blocks)
-  -- TODO - i was hoping <body> would be in here, but it starts with
-  -- the .cr-layout... not sure how to attach a class to <body>
 end
 
 -- Construct sticky sidebar AST

--- a/_extensions/closeread/grid.scss
+++ b/_extensions/closeread/grid.scss
@@ -118,3 +118,19 @@ body.cr-debug {
   }
 
 }
+
+/* remove header option */
+
+body.cr-removeheaderspace {
+  #quarto-content {
+    main#quarto-document-content {
+      padding-top: 0;
+      margin-top: 0;
+  
+      .quarto-title-block {
+        display: none;
+      }
+    }
+  }
+
+}

--- a/_extensions/closeread/scroller-init.js
+++ b/_extensions/closeread/scroller-init.js
@@ -10,14 +10,17 @@ const stepSelector = "[data-focus-on]"
 
 document.addEventListener("DOMContentLoaded", () => {
 
-  // if debugging, add .cr-debug to the body 
-  const debugOption = document
-    .querySelector("meta[cr-debug-mode]")?.getAttribute("cr-debug-mode")
-  const debugMode = debugOption === "true"
+  // attach config classes to <body>
+  const debugMode         = getBooleanConfig("debug-mode")
+  const removeHeaderSpace = getBooleanConfig("remove-header-space")
   if (debugMode) {
-    console.info("Close Read: debug mode ON")
     document.body.classList.add("cr-debug")
-  }
+  } 
+  if (removeHeaderSpace) {
+    document.body.classList.add("cr-removeheaderspace")
+  } 
+  console.log("Remove header space mode option was " + removeHeaderSpace)
+  
 
   // define an ojs variable if the connector module is available
   let focusedSticky = "none";
@@ -293,4 +296,12 @@ function scalePoemToSpan(el, highlightIds, paddingX = 75, paddingY = 50) {
   el.style.setProperty("transform",
     `matrix(${scale}, 0, 0, ${scale}, 0, ${centerDeltaY})`)
 
+}
+
+/* getBooleanConfig: checks for a <meta> with named attribute `cr-[metaFlag]`
+   and returns true if its value is "true" or false otherwise */
+function getBooleanConfig(metaFlag) {
+  const option = document
+    .querySelector("meta[cr-" + metaFlag + "]")?.getAttribute("cr-" + metaFlag)
+  return option === "true"
 }

--- a/docs/gallery/demos/a-poem-about-suffering/index.qmd
+++ b/docs/gallery/demos/a-poem-about-suffering/index.qmd
@@ -4,6 +4,8 @@ format:
     theme: nytimes.scss
     code-tools:
       source: true
+    # note that you can't see code-tools when this option is true
+    remove-header-space: true
 ---
 
 :::{.cr-layout}


### PR DESCRIPTION
Does what it says on the tin! In The Poem About the Suffering That Hides In Plain Sight, there's some space between the cr-layout and the website nav bar.

That's partly because of the title block and partly because of the default padding and margin above the main content.

Setting this option to true removes both. If you have a title block or options like code tools, those disappear — there might be something better we can do to relocate them, but this is a start for the common case where you want to start a page with a Closeread section!