### PR TITLE
Add devcontainer spec

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "Closeread (rocker/r-ver base)",
+    "image": "ghcr.io/rocker-org/devcontainer/r-ver:4.3",
+    "features": {
+        "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
+            "version": "prerelease" // latest quarto pre-release
+        },
+        "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+            "packages": "libudunits2-dev,libxtst6,libxt6,libmagick++-dev,librsvg2-dev,libgdal-dev,libgeos-dev,libproj-dev"
+        },
+        "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+            "packages": "github::rstudio/renv,tidyverse,here,httpgd,palmerpenguins,sf"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": ["mechatroner.rainbow-csv"]
+        }
+    }
+}


### PR DESCRIPTION
Very selfish PR here: I only brought my iPad with me on my trip, so I can’t contribute unless I do it through Codespaces 😛

This adds a container spec that includes R, Quarto, a few R packages (mostly just tidyverse and sf, as I was hoping to add a map example as well as a palmer penguins chart example) and other (imo) essentials for VSCode container work, like httpgd (for SVG chart previews).

Unfortunately I can’t get the port forwarding to work on my iPad on the train (it usually works fine though), so I can’t preview my work, but it’s a start!