### PR TITLE
Add `site-url`

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -5,6 +5,7 @@ project:
 
 website:
   title: "Closeread"
+  site-url: "https://closeread.dev"
   announcement: 
     icon: award
     dismissable: false


### PR DESCRIPTION
Fixes #175, where images and OJS resources (really any secondary resource) don't load if the trailing slash is dropped from the URL.

Recommending we merge straight into main, as it may cause problems on the preview branch (although IDK how it's handled with preview branches after this... we might need a profile system for CI/CD)